### PR TITLE
Add polyfill for object.assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import gulpHelp from 'gulp-help';
 import yargs from 'yargs';
 import runSequence from 'run-sequence';
 import loadPlugins from 'gulp-load-plugins';
+import assignPolyfill from 'lodash.assign';
 
 const CWD = process.cwd();
 const GULP_DIR = path.resolve(`${CWD}/gulp`);
@@ -17,6 +18,8 @@ const $ = loadPlugins({
 
 let gulp;
 let originalGulpConfig;
+
+Object.assign = Object.assign || assignPolyfill;
 
 try {
     originalGulpConfig = require(GULP_CONFIG_PATH);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp": "^3.9.1",
     "gulp-help": "^1.6.1",
     "gulp-load-plugins": "^1.2.2",
+    "lodash.assign": "^4.0.9",
     "run-sequence": "^1.1.5",
     "yargs": "^4.6.0"
   },


### PR DESCRIPTION
Would like to get this working on older node versions... So adding a polyfill for `Object.assign`. Should allow for use in 0.10+
